### PR TITLE
Fix Ksuid comparisons.

### DIFF
--- a/ksuid/ksuid.py
+++ b/ksuid/ksuid.py
@@ -76,7 +76,7 @@ class Ksuid:
         return self.__uid == other.__uid
 
     def __lt__(self, other):
-        return self.timestamp < other.timestamp
+        return self.__uid < other.__uid
 
     def __hash__(self):
         return int.from_bytes(self.__uid, "big")


### PR DESCRIPTION
We were comparing based only on the timestamp which was breaking ordering and
was also internally inconsistent because you could have two uids that
are not equal, but also not greater or lesser than each other.

Fixes #1