### PR TITLE
Simplify imports

### DIFF
--- a/ksuid/ksuid.py
+++ b/ksuid/ksuid.py
@@ -1,9 +1,9 @@
 import math
 import secrets
+import typing as t
 from datetime import datetime as datetime_lib
 from datetime import timezone
 from functools import total_ordering
-from typing import Optional, Type, TypeVar
 
 from baseconv import base62
 
@@ -17,7 +17,7 @@ class ByteArrayLengthException(Exception):
     pass
 
 
-SelfT = TypeVar("SelfT", bound="Ksuid")
+SelfT = t.TypeVar("SelfT", bound="Ksuid")
 
 
 @total_ordering
@@ -39,13 +39,13 @@ class Ksuid:
     _uid: bytes
 
     @classmethod
-    def from_base62(cls: Type[SelfT], data: str) -> SelfT:
+    def from_base62(cls: t.Type[SelfT], data: str) -> SelfT:
         """initializes Ksuid from base62 encoding"""
 
         return cls.from_bytes(int.to_bytes(int(base62.decode(data)), cls.BYTES_LENGTH, "big"))
 
     @classmethod
-    def from_bytes(cls: Type[SelfT], value: bytes) -> SelfT:
+    def from_bytes(cls: t.Type[SelfT], value: bytes) -> SelfT:
         """initializes Ksuid from bytes"""
 
         if len(value) != cls.TIMESTAMP_LENGTH_IN_BYTES + cls.PAYLOAD_LENGTH_IN_BYTES:
@@ -56,7 +56,7 @@ class Ksuid:
 
         return res
 
-    def __init__(self, datetime: Optional[datetime_lib] = None, payload: Optional[bytes] = None):
+    def __init__(self, datetime: t.Optional[datetime_lib] = None, payload: t.Optional[bytes] = None):
         if payload is not None and len(payload) != self.PAYLOAD_LENGTH_IN_BYTES:
             raise ByteArrayLengthException()
 

--- a/ksuid/ksuid.py
+++ b/ksuid/ksuid.py
@@ -1,8 +1,9 @@
 import math
 import secrets
-import typing as t
-from datetime import datetime, timezone
+from datetime import datetime as datetime_lib
+from datetime import timezone
 from functools import total_ordering
+from typing import Optional, Type, TypeVar
 
 from baseconv import base62
 
@@ -16,7 +17,7 @@ class ByteArrayLengthException(Exception):
     pass
 
 
-SelfT = t.TypeVar("SelfT", bound="Ksuid")
+SelfT = TypeVar("SelfT", bound="Ksuid")
 
 
 @total_ordering
@@ -38,13 +39,13 @@ class Ksuid:
     _uid: bytes
 
     @classmethod
-    def from_base62(cls: t.Type[SelfT], data: str) -> SelfT:
+    def from_base62(cls: Type[SelfT], data: str) -> SelfT:
         """initializes Ksuid from base62 encoding"""
 
         return cls.from_bytes(int.to_bytes(int(base62.decode(data)), cls.BYTES_LENGTH, "big"))
 
     @classmethod
-    def from_bytes(cls: t.Type[SelfT], value: bytes) -> SelfT:
+    def from_bytes(cls: Type[SelfT], value: bytes) -> SelfT:
         """initializes Ksuid from bytes"""
 
         if len(value) != cls.TIMESTAMP_LENGTH_IN_BYTES + cls.PAYLOAD_LENGTH_IN_BYTES:
@@ -55,9 +56,7 @@ class Ksuid:
 
         return res
 
-    def __init__(self, datetime: t.Optional[datetime] = None, payload: t.Optional[bytes] = None):
-        from datetime import datetime as datetime_lib
-
+    def __init__(self, datetime: Optional[datetime_lib] = None, payload: Optional[bytes] = None):
         if payload is not None and len(payload) != self.PAYLOAD_LENGTH_IN_BYTES:
             raise ByteArrayLengthException()
 
@@ -86,16 +85,16 @@ class Ksuid:
     def __hash__(self) -> int:
         return int.from_bytes(self._uid, "big")
 
-    def _inner_init(self, dt: datetime, payload: bytes) -> bytes:
-        timestamp = int(dt.timestamp() - EPOCH_STAMP)
+    def _inner_init(self, datetime: datetime_lib, payload: bytes) -> bytes:
+        timestamp = int(datetime.timestamp() - EPOCH_STAMP)
 
         return int.to_bytes(timestamp, self.TIMESTAMP_LENGTH_IN_BYTES, "big") + payload
 
     @property
-    def datetime(self) -> datetime:
+    def datetime(self) -> datetime_lib:
         unix_time = self.timestamp
 
-        return datetime.fromtimestamp(unix_time, tz=timezone.utc)
+        return datetime_lib.fromtimestamp(unix_time, tz=timezone.utc)
 
     @property
     def timestamp(self) -> float:
@@ -121,8 +120,8 @@ class KsuidMs(Ksuid):
 
     TIMESTAMP_MULTIPLIER = 256
 
-    def _inner_init(self, dt: datetime, payload: bytes) -> bytes:
-        timestamp = round((dt.timestamp() - EPOCH_STAMP) * self.TIMESTAMP_MULTIPLIER)
+    def _inner_init(self, datetime: datetime_lib, payload: bytes) -> bytes:
+        timestamp = round((datetime.timestamp() - EPOCH_STAMP) * self.TIMESTAMP_MULTIPLIER)
 
         return int.to_bytes(timestamp, self.TIMESTAMP_LENGTH_IN_BYTES, "big") + payload
 


### PR DESCRIPTION
No need to re-import datetime as datetime_lib inside `__init__`, just import it as that in the outer scope once.
Import the typing members directly.
