### PR TITLE
gha: set timeout-minutes on CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 on: [pull_request]
 jobs:
   lint:
+    timeout-minutes: 2
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -18,6 +19,7 @@ jobs:
       - name: Run linting
         run: uv run sh ./scripts/lint.sh
   prek:
+    timeout-minutes: 5
     name: Validate prek
     runs-on: ubuntu-24.04
     steps:
@@ -25,6 +27,7 @@ jobs:
       - uses: astral-sh/setup-uv@v8.2.0
       - uses: j178/prek-action@v2
   test:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -41,6 +44,7 @@ jobs:
       - name: Run linting
         run: uv run pytest
   build:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: [prek, lint, test]
     steps:


### PR DESCRIPTION
CI for #62 just happened to get stuck for 38 minutes (looks like a broken github actions runner). Let's set low timeouts so that we don't waste an unbounded number of worker minutes if we happen to get a bad worker.