### PR TITLE
Handle oversized base62 values

### DIFF
--- a/ksuid/ksuid.py
+++ b/ksuid/ksuid.py
@@ -48,7 +48,13 @@ class Ksuid:
     @classmethod
     def from_base62(cls: type[SelfT], data: str) -> SelfT:
         """initializes Ksuid from base62 encoding"""
-        return cls.from_bytes(int.to_bytes(int(base62.decode(data)), cls.BYTES_LENGTH, "big"))
+        decoded = int(base62.decode(data))
+        try:
+            value = int.to_bytes(decoded, cls.BYTES_LENGTH, "big")
+        except OverflowError as exc:
+            byte_length = (decoded.bit_length() + 7) // 8
+            raise ByteArrayLengthException(f"Incorrect value length {byte_length}") from exc
+        return cls.from_bytes(value)
 
     @classmethod
     def from_bytes(cls: type[SelfT], value: bytes) -> SelfT:

--- a/tests/test_ksuid.py
+++ b/tests/test_ksuid.py
@@ -72,6 +72,12 @@ def test_to_from_base62():
     assert ksuid == ksuid_from_base62
 
 
+@pytest.mark.parametrize("ksuid_cls", [Ksuid, KsuidMs])
+def test_from_base62_rejects_oversized_value(ksuid_cls):
+    with pytest.raises(ByteArrayLengthException):
+        ksuid_cls.from_base62("z" * ksuid_cls.BASE62_LENGTH)
+
+
 def test_eq_with_non_ksuid_does_not_raise():
     ksuid = Ksuid.from_bytes(bytes(Ksuid.BYTES_LENGTH))
 


### PR DESCRIPTION
## Summary
- convert oversized base62 decoded values from a raw `OverflowError` into `ByteArrayLengthException`
- add coverage for 27-character base62 values that exceed the 20-byte KSUID range for both `Ksuid` and `KsuidMs`

## Tests
- `uv run pytest`
- `uv run ./scripts/lint.sh`
- `uv run ruff check ksuid tests`
- `uv run ruff format --check ksuid tests`
- `python -m compileall -q ksuid tests`
- `git diff --check`
